### PR TITLE
fix(client): Job not found on QBCore upon player load

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -26,7 +26,10 @@ CreateThread(function()
         end)
     elseif framework == 'qb' then
         QBCore = exports['qb-core']:GetCoreObject()
-        PlayerData = QBCore.Functions.GetPlayerData()
+
+        RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+            PlayerData = QBCore.Functions.GetPlayerData()
+        end)
 
         RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
             PlayerData.job = job


### PR DESCRIPTION
Fix PlayerData not loaded on first player load. Otherwise user has to switch jobs to receive the job value.